### PR TITLE
chore(.gitignore): stop ignoring .luaurc and add to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 /DevPackages
 /Packages
 /sourcemap.json
-/.luaurc
 /.vscode

--- a/.luaurc
+++ b/.luaurc
@@ -1,0 +1,6 @@
+{
+    "languageMode": "strict",
+    "aliases": {
+        "lune": "~/.lune/.typedefs/0.10.1/"
+    }
+}


### PR DESCRIPTION
**why**
`.luaurc` shouldn't be in .gitignore. it helps ensure consistent settings across contributors, like language mode (**--strict** vs **nonstrict**). aliases too (i include lune aliases in this rc.)