### PR TITLE
chore: add typed definitions for _G

### DIFF
--- a/types/_G.d.luau
+++ b/types/_G.d.luau
@@ -1,0 +1,5 @@
+declare _G: {
+	__DEV__: boolean?,
+	__IGNORE_INSTANCES_WARNING__: boolean?,
+	NOCOLOR: boolean?
+}


### PR DESCRIPTION
**why**
luau currently infers `_G` as `any`. this pr adds explicit typings to improve type checking and autocompletion.

**supported types:**
| name| type |
|-----------|-------|
| `__DEV__` | boolean? | 
| `__IGNORE_INSTANCES_WARNING__` | boolean? |
| `NOCOLOR` | boolean? | 

**vscode setup**
if you're using vscode with luau-lsp, add the following to your `.vscode/settings.json`:
```json
{
    "luau-lsp.types.definitionFiles": [
        "types/_G.d.luau"
    ]
}
```